### PR TITLE
handling relative images in readme

### DIFF
--- a/app/src/components/student/Readme.tsx
+++ b/app/src/components/student/Readme.tsx
@@ -9,26 +9,49 @@ type propsType = {
     readmeUrl: string
 }
 
+
+
 function b64DecodeUnicode(str: any) {
-    return decodeURIComponent(Array.prototype.map.call(window.atob(str), function(c: any) {
+    return decodeURIComponent(Array.prototype.map.call(window.atob(str), function (c: any) {
         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
     }).join(''))
 }
 
+function getRepoAddr(url: string) {
+    console.log(url)
+    //for a readme url, returns string: "[username]/[repository name]"
+    try {
+        let temp = url.split("/")
+        return temp.splice(temp.indexOf("repos") + 1, 2).join("/")
+
+    } catch (error) {
+        return ""
+    }
+
+}
+
+
+
 const Readme = (props: propsType) => {
+
 
     const [readmeText, setReadmeText] = useState("");
     const [topicName, setTopicName] = useState("");
+
+    function prefixImageSources(text: string, repoPath: string) {
+        console.log(repoPath)
+        return text.replace(/\!\[(.*?)\]\((?!.*[a-z]\:\/\/)(.*?)\)/g, "![$1](https://raw.githubusercontent.com/" + repoPath + "/main/$2)")
+    }
 
     useEffect(() => {
         setTopicName(props.topicName);
         axios({
             url: props.readmeUrl,
             method: "get"
-            }).then((response: any) => {
+        }).then((response: any) => {
             return response.data.content
         }).then((res) => {
-            setReadmeText(b64DecodeUnicode(res))
+            setReadmeText(prefixImageSources(b64DecodeUnicode(res), getRepoAddr(props.readmeUrl)))
         }).catch((e) => {
             console.error("cannot fetch readme: " + e);
         })
@@ -38,7 +61,7 @@ const Readme = (props: propsType) => {
     return (
         <Card id="readme" className="w-80">
             {topicName === "" ?
-                <div/>
+                <div />
                 :
                 <Card.Header>
                     {topicName}

--- a/app/src/components/student/StudentPage.css
+++ b/app/src/components/student/StudentPage.css
@@ -6,7 +6,9 @@
     max-height: 80vh;
 }
 
-
+#readme img{
+    max-width: 100%;
+}
 
 #checkpoints ol, #readme .card-body {
     height: 100%;


### PR DESCRIPTION
# What does it do?

It replaces every instance of:

`!(IMAGE_ALT)[IMAGE_SRC]`

where `IMAGE_SRC` does NOT begin with a protocol prefix (http://, https://, ftp://)

with:

`!(IMAGE_ALT)[https://raw.githubusercontent.com/RELATIVE_PATH/main/IMAGE_SRC]`

where `RELATIVE_PATH` is a string `username/repository name` extracted directly from readme url.

Tested on [MCjasiux/Ewolucja](https://github.com/MCjasiux/Ewolucja) and  [youngdashu/Investments-overview](https://github.com/youngdashu/Investments-overview)